### PR TITLE
Use certificate authentication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ else()
 endif()
 
 include_directories(${CMAKE_SOURCE_DIR}/submodules/msquic/src/inc)
+# Use the same OpenSSL version as MsQuic
+include_directories(${CMAKE_SOURCE_DIR}/submodules/msquic/submodules/openssl/include)
 include_directories(${CMAKE_SOURCE_DIR}/src/inc)
 
 set(QUIC_TLS "openssl")

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
     api.cpp
+    auth.cpp
     engine.cpp
     messages.cpp
 )

--- a/src/core/auth.cpp
+++ b/src/core/auth.cpp
@@ -1,0 +1,167 @@
+/*
+    Licensed under the MIT License.
+*/
+#include "precomp.h"
+#include "openssl/err.h"
+#include "openssl/evp.h"
+#include "openssl/pkcs12.h"
+#include "openssl/x509.h"
+
+// GetCert
+// GetRootCert
+
+bool
+QuicLanGenerateAuthCertificate(
+    _Out_ std::unique_ptr<uint8_t[]>& Pkcs12,
+    _Out_ uint32_t& Pkcs12Length)
+{
+    EVP_PKEY* PrivateKey = nullptr;
+    X509* SelfSignedCert = nullptr;
+    X509_NAME* Name = nullptr;
+    PKCS12* NewPkcs12 = nullptr;
+    uint8_t* Pkcs12Buffer = nullptr;
+    uint8_t* Pkcs12BufferPtr = nullptr;
+    int Ret = 0;
+    bool Result = false;
+
+    Pkcs12 = nullptr;
+    Pkcs12Length = 0;
+
+    EVP_PKEY_CTX *KeyContext = EVP_PKEY_CTX_new_id(EVP_PKEY_ED448, NULL);
+    if (KeyContext == nullptr) {
+        printf("Failed to allocate Key context!\n");
+        goto Error;
+    }
+
+    Ret = EVP_PKEY_keygen_init(KeyContext);
+    if (Ret != 1) {
+        printf("Keygen init failed!\n");
+        goto Error;
+    }
+
+    Ret = EVP_PKEY_keygen(KeyContext, &PrivateKey);
+    if (Ret != 1) {
+        printf("Keygen failed!\n");
+        goto Error;
+    }
+
+    SelfSignedCert = X509_new();
+    if (SelfSignedCert == nullptr) {
+        printf("Failed to allocate X509!\n");
+        goto Error;
+    }
+
+    Ret = X509_set_version(SelfSignedCert, 2);
+    if (Ret != 1) {
+        printf("Failed to set certificate version!\n");
+        goto Error;
+    }
+
+    Ret = ASN1_INTEGER_set(X509_get_serialNumber(SelfSignedCert), 1);
+    if (Ret != 1) {
+        printf("Failed to set serial number!\n");
+        goto Error;
+    }
+
+    X509_gmtime_adj(X509_get_notBefore(SelfSignedCert), -300);
+    X509_gmtime_adj(X509_get_notAfter(SelfSignedCert), 31536000L);
+
+    Ret = X509_set_pubkey(SelfSignedCert, PrivateKey);
+    if (Ret != 1) {
+        printf("Failed to set public key on cert!\n");
+        goto Error;
+    }
+
+    Name = X509_get_subject_name(SelfSignedCert);
+    if (Name == nullptr) {
+        printf("Failed to allocate subject name!\n");
+        goto Error;
+    }
+    Ret = X509_NAME_add_entry_by_txt(Name, "CN", MBSTRING_ASC, (unsigned char*)"quicLAN", -1, -1, 0);
+    if (Ret != 1) {
+        printf("Failed to set subject name!\n");
+        goto Error;
+    }
+
+    Ret = X509_set_issuer_name(SelfSignedCert, Name);
+    if (Ret != 1) {
+        printf("Failed to set issuer name!\n");
+        goto Error;
+    }
+
+    Ret = X509_sign(SelfSignedCert, PrivateKey, nullptr);
+    if (Ret == 0) {
+        printf("Failed to sign certificate!\n");
+        goto Error;
+    }
+
+    NewPkcs12 = PKCS12_create("", "quicLAN", PrivateKey, SelfSignedCert, nullptr, -1, -1, 0, 0, 0);
+    if (NewPkcs12 == nullptr) {
+        printf("Failed to create new PKCS12!\n");
+        goto Error;
+    }
+
+    Ret = i2d_PKCS12(NewPkcs12, nullptr);
+    if (Ret <= 0) {
+        printf("Failed to get export buffer size of NewPkcs12!\n");
+        goto Error;
+    }
+
+    Pkcs12Length = Ret;
+
+    Pkcs12Buffer = new (std::nothrow) uint8_t[Pkcs12Length];
+    if (Pkcs12Buffer == nullptr) {
+        printf("Failed to allocate %u bytes for Pkcs12!\n", Pkcs12Length);
+        goto Error;
+    }
+
+    Pkcs12BufferPtr = Pkcs12Buffer;
+
+    Ret = i2d_PKCS12(NewPkcs12, &Pkcs12BufferPtr);
+    if (Ret < 0) {
+        printf("Failed to export NewPkcs12!\n");
+        goto Error;
+    }
+
+    if (Ret != Pkcs12Length) {
+        printf("Pkcs12 export length changed between calls!\n");
+        goto Error;
+    }
+
+    Result = true;
+    Pkcs12.reset(Pkcs12Buffer);
+    Pkcs12Buffer = nullptr;
+
+Error:
+
+    if (Pkcs12Buffer != nullptr) {
+        delete[] Pkcs12Buffer;
+    }
+
+    if (NewPkcs12 != nullptr) {
+        PKCS12_free(NewPkcs12);
+    }
+
+    if (SelfSignedCert != nullptr) {
+        X509_free(SelfSignedCert);
+    }
+
+    if (PrivateKey != nullptr) {
+        EVP_PKEY_free(PrivateKey);
+    }
+
+    if (KeyContext != nullptr) {
+        EVP_PKEY_CTX_free(KeyContext);
+    }
+
+    return Result;
+}
+
+
+bool
+QuicLanVerifyCertificate(
+    _In_ QUIC_CERTIFICATE* Cert)
+{
+    X509* PeerCert = (X509*)Cert;
+    return true;
+}

--- a/src/core/auth.h
+++ b/src/core/auth.h
@@ -4,9 +4,11 @@
 
 bool
 QuicLanGenerateAuthCertificate(
+    _In_ const std::string& Password,
     _Out_ std::unique_ptr<uint8_t[]>& Pkcs12,
     _Out_ uint32_t& Pkcs12Length);
 
 bool
 QuicLanVerifyCertificate(
+    _In_ const std::string& Password,
     _In_ QUIC_CERTIFICATE* Cert);

--- a/src/core/auth.h
+++ b/src/core/auth.h
@@ -1,0 +1,12 @@
+/*
+    Licensed under the MIT License.
+*/
+
+bool
+QuicLanGenerateAuthCertificate(
+    _Out_ std::unique_ptr<uint8_t[]>& Pkcs12,
+    _Out_ uint32_t& Pkcs12Length);
+
+bool
+QuicLanVerifyCertificate(
+    _In_ QUIC_CERTIFICATE* Cert);

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -757,7 +757,7 @@ QuicLanEngine::ClientConnectionCallback(
     case QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_RECEIVED: {
         if (!QuicLanVerifyCertificate(This->Engine->Password, Event->PEER_CERTIFICATE_RECEIVED.Certificate)) {
             printf("Peer failed certificate validation!\n");
-            This->Engine->MsQuic->ConnectionShutdown(Connection, QUIC_CONNECTION_SHUTDOWN_FLAG_NONE, QUIC_STATUS_CONNECTION_REFUSED);
+            Status = QUIC_STATUS_CONNECTION_REFUSED;
         } else {
             This->State.Authenticated = true;
         }
@@ -878,7 +878,7 @@ QuicLanEngine::ServerConnectionCallback(
     case QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_RECEIVED: {
         if (!QuicLanVerifyCertificate(This->Engine->Password, Event->PEER_CERTIFICATE_RECEIVED.Certificate)) {
             printf("Peer failed certificate validation!\n");
-            This->Engine->MsQuic->ConnectionShutdown(Connection, QUIC_CONNECTION_SHUTDOWN_FLAG_NONE, QUIC_STATUS_CONNECTION_REFUSED);
+            Status = QUIC_STATUS_CONNECTION_REFUSED;
         } else {
             This->State.Authenticated = true;
         }

--- a/src/core/engine.h
+++ b/src/core/engine.h
@@ -18,8 +18,6 @@ struct QuicLanPeerContext {
     struct {
         uint32_t AddressReserved : 1;
         uint32_t Connected : 1;
-        uint32_t Authenticating : 1;
-        uint32_t AuthenticationFailed : 1;
         uint32_t Authenticated : 1;
         uint32_t TimedOut : 1;
         uint32_t Disconnecting : 1;
@@ -133,7 +131,7 @@ struct QuicLanEngine {
 
     FN_TUNNEL_EVENT_CALLBACK EventHandler;
 
-    char Password[255];
+    std::string Password;
 
     char ServerAddress[255];
     uint16_t ServerPort;

--- a/src/core/engine.h
+++ b/src/core/engine.h
@@ -55,11 +55,6 @@ struct QuicLanEngine {
     StartServer(
         _In_ uint16_t ListenerPort);
 
-    bool
-    ClientAuthenticationStart(
-        _In_ HQUIC AuthStream,
-        _In_ QuicLanPeerContext* PeerContext);
-
     void
     IncrementOutstandingDatagrams();
 
@@ -107,37 +102,10 @@ struct QuicLanEngine {
     _Function_class_(QUIC_CONNECTION_CALLBACK)
     QUIC_STATUS
     QUIC_API
-    ServerUnauthenticatedConnectionCallback(
+    ServerConnectionCallback(
         _In_ HQUIC Connection,
         _In_opt_ void* Context,
         _Inout_ QUIC_CONNECTION_EVENT* Event);
-
-    static
-    _Function_class_(QUIC_CONNECTION_CALLBACK)
-    QUIC_STATUS
-    QUIC_API
-    ServerAuthenticatedConnectionCallback(
-        _In_ HQUIC Connection,
-        _In_opt_ void* Context,
-        _Inout_ QUIC_CONNECTION_EVENT* Event);
-
-    static
-    _Function_class_(QUIC_STREAM_CALLBACK)
-    QUIC_STATUS
-    QUIC_API
-    ServerAuthStreamCallback(
-        _In_ HQUIC Stream,
-        _In_opt_ void* Context,
-        _Inout_ QUIC_STREAM_EVENT* Event);
-
-    static
-    _Function_class_(QUIC_STREAM_CALLBACK)
-    QUIC_STATUS
-    QUIC_API
-    ClientAuthStreamCallback(
-        _In_ HQUIC Stream,
-        _In_opt_ void* Context,
-        _Inout_ QUIC_STREAM_EVENT* Event);
 
     static
     _Function_class_(QUIC_STREAM_CALLBACK)

--- a/src/core/precomp.h
+++ b/src/core/precomp.h
@@ -25,6 +25,7 @@
 #include <thread>
 #include <string.h>
 
+#include "auth.h"
 #include "timer.h"
 #include "messages.h"
 #include "workitem.h"


### PR DESCRIPTION
Instead of sending a tunneled, clear-text password for verification, generate certificates and sign them with a key derived from the password. During the handshake, verify the signatures on the certificates, and allow the connection to succeed if verification succeeds.