### PR TITLE
Fix spurious hangs.

### DIFF
--- a/src/core/api.cpp
+++ b/src/core/api.cpp
@@ -15,7 +15,7 @@ InitializeQuicLanEngine(
     }
     *Engine = nullptr;
 
-    QuicLanEngine* NewEngine = new(std::nothrow) QuicLanEngine;
+    QuicLanEngine* NewEngine = new(std::nothrow) QuicLanEngine();
     if (NewEngine == nullptr) {
         printf("Failed to allocate engine!\n");
         return false;

--- a/src/core/engine.h
+++ b/src/core/engine.h
@@ -155,13 +155,13 @@ struct QuicLanEngine {
     uint16_t DatagramsOutstanding = 0;
 
     std::mutex StopLock;
+    std::atomic_bool Stopped;
     std::condition_variable StopCv;
 
     uint16_t MaxDatagramLength = MaxPacketLength; // Calculated as the min() of all connections' MTUs.
 
     uint16_t ID; // The low two bytes of the VPN IP address.
 
-    bool ShuttingDown = false;
     bool IdRequested = false;
     bool IdAssigned = false;
 };


### PR DESCRIPTION
During testing, the second end-to-end test would hang on shutdown.  This change fixes that and other rare hangs and crashes.