### PR TITLE
Ensure SerialNumber uses all 64 bytes always.

### DIFF
--- a/src/core/auth.cpp
+++ b/src/core/auth.cpp
@@ -98,6 +98,10 @@ QuicLanGenerateAuthCertificate(
         goto Error;
     }
 
+    // Ensure the salt is the full length by setting the
+    // MSB to 1 always.
+    Salt[0] |= 0x80;
+
     Cert = X509_new();
     if (Cert == nullptr) {
         printf("Failed to allocate X509!\n");
@@ -263,13 +267,13 @@ QuicLanVerifyCertificate(
         goto Error;
     }
 
-    if (BN_num_bytes(SaltBn) > sizeof(Salt)) {
+    if (BN_num_bytes(SaltBn) != sizeof(Salt)) {
         printf("Serial number is not correct size! %u vs %u\n", BN_num_bytes(SaltBn), sizeof(Salt));
         goto Error;
     }
 
     Ret = BN_bn2bin(SaltBn, Salt);
-    if (Ret > sizeof(Salt)) {
+    if (Ret != sizeof(Salt)) {
         printf("BIGNUM conversion to binary is wrong size! %u vs %u\n", Ret, sizeof(Salt));
         goto Error;
     }


### PR DESCRIPTION
Fix a rare bug where the RNG generates a serial number with a leading byte that is zero. This causes the serial number to fail certificate validation.
The fix ensures that the most significant bit is always one, which makes the serial number always negative, but ensures that the entire 64 bytes are used, no matter how many leading bytes are zero.